### PR TITLE
adds cmake options to get ptx code and more verbose nvcc.

### DIFF
--- a/src/gpu/CMakeLists.txt
+++ b/src/gpu/CMakeLists.txt
@@ -4,6 +4,28 @@ cmake_minimum_required(VERSION 2.8)
 find_package(CUDA)
 
 if(CUDA_FOUND)
+
+  # set(CUDA_VERBOSE_BUILD ON)
+
+  option(CUDA_VERBOSE_PTXAS "On to enable verbose output from the PTX assembler." OFF)
+  if (CUDA_VERBOSE_PTXAS)
+    ### Note: do not use quotation marks in set() to get delimiter ';' for the list elems.
+    set(MORE_NVCC_FLAGS -res-usage --ptxas-options=-v)
+  endif ()
+
+  option(CUDA_OUTPUT_INTERMEDIATE_CODE "Output PTX code and other intermediates." OFF)
+  if(CUDA_OUTPUT_INTERMEDIATE_CODE)
+    list(APPEND MORE_NVCC_FLAGS
+      --keep
+      --keep-dir=${CMAKE_BINARY_DIR}/src/gpu/
+      --source-in-ptx)
+  endif(CUDA_OUTPUT_INTERMEDIATE_CODE)
+
+  option(PTXAS_MORE_WARNINGS "More PTX warnings" OFF)
+  if(PTXAS_MORE_WARNINGS)
+    list(APPEND MORE_NVCC_FLAGS -Xptxas -warn-double-usage,-warn-lmem-usage,-warn-spills)
+  endif()
+
   # caches variable, accessible by ccmake
   set(MCEA_CUDA_ARCH "" CACHE STRING "Target Compute Capability, e.g. '52' or '' = automatic (linux).")
 
@@ -30,7 +52,23 @@ if(CUDA_FOUND)
   # if c++11 or c++14 flags cause problems, try to turn this on
   # set(CUDA_PROPAGATE_HOST_FLAGS OFF)
 
-  FILE(GLOB CONFIG_FILES "../config/*.cmake" )
+  set(SOURCES_UTIL ../util/output.cu
+    ../util/random.cu
+    ../util/dtlz.cu
+    ../util/weighting.cu
+    ../util/neighbor.cu
+    ../util/config.h
+    ../util/error.h
+    ../util/dtlz.cuh
+    ../util/output.cuh
+    ../util/random.cuh
+    ../util/weighting.cuh
+    ../util/neighbor.cuh)
+  set(SOURCES_SYNC mcea_sync.cu ${SOURCES_UTIL})
+  set(SOURCES_ASYNC mcea_async.cu ${SOURCES_UTIL})
+
+  FILE(GLOB CONFIG_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../config/*.cmake" )
+
   FOREACH(CFILE ${CONFIG_FILES})
     FILE(READ ${CFILE} CONFIG)
     STRING(REGEX REPLACE ";" "\\\\;" CONFIG "${CONFIG}")
@@ -47,56 +85,41 @@ if(CUDA_FOUND)
     SET(OUTFILE "\"${OUTFILE}${CONFIG}\"")
 
     set(
-        CUDA_NVCC_FLAGS
-        -arch=sm_${MCEA_CUDA_ARCH}
-        --relocatable-device-code true
-        --use_fast_math
-        -DSTOPTYPE=${STOPTYPE}
-        -DSTOPVALUE=${STOPVALUE}
-        -DPOP_WIDTH=${POP_WIDTH}
-        -DPARAMS=${PARAMS}
-        -DN_RAD=${N_RAD}
-        -DTHREADS=${THREADS}
-        -DVADS_SCALE=${VADS_SCALE}
-        -DOUTFILE=${OUTFILE}
-        -DDTLZ_NUM=${DTLZ_NUM}
-        )
+      CUDA_NVCC_FLAGS
+      -arch=sm_${MCEA_CUDA_ARCH}
+      --relocatable-device-code true
+      -lineinfo
+      --use_fast_math
+      -DSTOPTYPE=${STOPTYPE}
+      -DSTOPVALUE=${STOPVALUE}
+      -DPOP_WIDTH=${POP_WIDTH}
+      -DPARAMS=${PARAMS}
+      -DN_RAD=${N_RAD}
+      -DTHREADS=${THREADS}
+      -DVADS_SCALE=${VADS_SCALE}
+      -DOUTFILE=${OUTFILE}
+      -DDTLZ_NUM=${DTLZ_NUM}
+      ${MORE_NVCC_FLAGS}
+      )
+
+## directly generates ptx code (but without verbose and warnings?)
+#     if(CUDA_OUTPUT_INTERMEDIATE_CODE)
+#       cuda_compile_ptx(
+#         cuda_ptx_files
+#         mcea_sync.cu mcea_async.cu ${SOURCES_UTIL}
+# #        OPTIONS --source-in-ptx ${MORE_PTXAS_FLAGS}
+#         )
+#       add_custom_target(ptx${CONFIG} ALL
+#         DEPENDS ${cuda_ptx_files}
+#         SOURCES mcea_sync.cu mcea_async.cu ${SOURCES_UTIL}
+#         )
+#     endif()
+
 
     # For compilation ...
     # Specify target & source files to compile it from
-    cuda_add_executable(
-        mcea_sync${CONFIG}
-        mcea_sync.cu
-        ../util/output.cu
-        ../util/random.cu
-        ../util/dtlz.cu
-        ../util/weighting.cu
-        ../util/neighbor.cu
-        ../util/config.h
-        ../util/error.h
-        ../util/dtlz.cuh
-        ../util/output.cuh
-        ../util/random.cuh
-        ../util/weighting.cuh
-        ../util/neighbor.cuh
-        )
-
-    cuda_add_executable(
-        mcea_async${CONFIG}
-        mcea_async.cu
-        ../util/output.cu
-        ../util/random.cu
-        ../util/dtlz.cu
-        ../util/weighting.cu
-        ../util/neighbor.cu
-        ../util/config.h
-        ../util/error.h
-        ../util/dtlz.cuh
-        ../util/output.cuh
-        ../util/random.cuh
-        ../util/weighting.cuh
-        ../util/neighbor.cuh
-        )
+    cuda_add_executable(mcea_sync${CONFIG} ${SOURCES_SYNC})
+    cuda_add_executable(mcea_async${CONFIG} ${SOURCES_ASYNC})
 
     # For linking ...
     # Specify target & libraries to link it with
@@ -115,6 +138,7 @@ if(CUDA_FOUND)
       )
 
   ENDFOREACH()
+
 else()
   message(STATUS "CUDA deselected, toolchain not found on system")
 endif()


### PR DESCRIPTION
- also includes path fix for config files (see #3 )

- CUDA_VERBOSE_PTXAS
  - shows kernel statistics like register and lmem usage
- CUDA_OUTPUT_INTERMEDIATE_CODE
  - keeps intermediate code files like ptx (source-correlation in ptx enabled)
- PTXAS_MORE_WARNINGS
  - gives warnings when doubles are used in an [float] instruction
  - warns if local memory is used
  - warns if regs are spilled to local memory
- also adds `-lineinfo` for code-correlation tool in nvvp

You can chase down the warnings to find spots for local memory issues, although the most part is due to curand. The doubles still can be found in the ptx code as 64-bit values, not sure if driver takes them as they are.. have not checked SASS dump (for SASS ref, see [doc](http://docs.nvidia.com/cuda/cuda-binary-utilities/index.html#instruction-set-ref)).

I also added variables that contain the SOURCE files. There is a commented block where ptx code directly can be generated. But when enabled and targeted with make `ptx*` warnings and verbose output are not shown, so I would stay for the `--keep` flag for nvcc, where all intermediate files will be kept for introspection afterwards.